### PR TITLE
Add more ViewHelpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ For further infomation about some of the snippets lookup the TYPO3 Fluid documen
 
 ## Contributing
 
-If you'd like to send a pull request please make sure that you have a working [editorconfig](http://editorconfig.org) plugin installed.
+If you'd like to send a pull request please make sure that you have a working [editorconfig](http://editorconfig.org) plugin installed!

--- a/snippets/fluid.json
+++ b/snippets/fluid.json
@@ -20,6 +20,41 @@
     ],
     "description": "TYPO3 Fluid Inline | {f:alias(})}"
   },
+  "f:base": {
+    "prefix": "fBase",
+    "body": [
+      "<f:base />"
+    ],
+    "description": "TYPO3 Fluid | <f:base>"
+  },
+  "f:cache.disable": {
+    "prefix": "fCacheDisable",
+    "body": [
+      "<f:cache.disable />"
+    ],
+    "description": "TYPO3 Fluid | <f:cache.disable>"
+  },
+  "f:cache.disable Inline": {
+    "prefix": "fCacheDisableInline",
+    "body": [
+      "{f:cache.disable()}"
+    ],
+    "description": "TYPO3 Fluid Inline | {f:cache.disable()}"
+  },
+  "f:cache.static": {
+    "prefix": "fCacheStatic",
+    "body": [
+      "<f:cache.static>$1</f:cache.static>"
+    ],
+    "description": "TYPO3 Fluid | <f:cache.static>"
+  },
+  "f:cache.warmup": {
+    "prefix": "fCacheWarmup",
+    "body": [
+      "<f:cache.warmup variables=\"{$1: $2}\"></f:cache.warmup"
+    ],
+    "description": "TYPO3 Fluid Inline | <f:cache.warmup>"
+  },
   "f:cObject": {
     "prefix": "fCobject",
     "body": [
@@ -292,6 +327,20 @@
     ],
     "description": "TYPO3 Fluid Inline | {f:format.htmlspecialchars()}"
   },
+  "f:format.htmlspecialchars": {
+    "prefix": "fFormatHtmlspecialchars",
+    "body": [
+      "<f:format.htmlspecialchars${1: keepQuotes=\"1\"}${2: doubleEncode=\"1\"}>$3</f:format.htmlspecialchars>"
+    ],
+    "description": "TYPO3 Fluid | <f:format.htmlspecialchars>"
+  },
+  "f:format.htmlspecialchars Inline": {
+    "prefix": "fFormatHtmlspecialcharsInline",
+    "body": [
+      "{f:format.htmlspecialchars(value: '$1'${2:, keepQuotes: 1}${3:, doubleEncode: 1})}"
+    ],
+    "description": "TYPO3 Fluid Inline | {f:format.htmlspecialchars()}"
+  },
   "f:format.nl2br": {
     "prefix": "fFormatNl2br",
     "body": [
@@ -429,6 +478,27 @@
     ],
     "description": "TYPO3 Fluid | <f:image>"
   },
+  "f:inline": {
+    "prefix": "fInline",
+    "body": [
+      "{$1 -> f:inline()}"
+    ],
+    "description": "TYPO3 Fluid | {f:inline()}"
+  },
+  "f:layout": {
+    "prefix": "fLayout",
+    "body": [
+      "<f:layout name=\"$1\"/>"
+    ],
+    "description": "TYPO3 Fluid | <f:layout>"
+  },
+  "f:section": {
+    "prefix": "fSection",
+    "body": [
+      "<f:section name=\"$1\"/>"
+    ],
+    "description": "TYPO3 Fluid | <f:section>"
+  },
   "f:link.action": {
     "prefix": "fLinkAction",
     "body": [
@@ -513,12 +583,20 @@
     ],
     "description": "TYPO3 Fluid | {f:render()}"
   },
+  "f:spaceless": {
+    "prefix": "fSpaceless",
+    "body": [
+      "<f:spaceless>{$1}</f:spaceless>"
+    ],
+    "description": "TYPO3 Fluid | <f:spaceless>"
+  },
   "f:switch": {
     "prefix": "fSwitch",
     "body": [
       "<f:switch expression=\"{$1}\">",
       "\t<f:case value=\"$2\">$3</f:case>",
       "\t<f:case default=\"TRUE\">$4</f:case>",
+      "\t<f:defaultCase>$5</f:defaultCase>",
       "</f:switch>"
     ],
     "description": "TYPO3 Fluid | <f:switch>"
@@ -627,5 +705,26 @@
       "{f:uri.typolink(parameter: '$1')}"
     ],
     "description": "TYPO3 Fluid Inline | {f:uri.typolink()}"
+  },
+  "f:variable": {
+    "prefix": "fVariableTagNotation2",
+    "body": [
+      "<f:variable name=\"$1\">$2</f:variable>"
+    ],
+    "description": "TYPO3 Fluid | <f:variable>"
+  },
+  "f:variable Value as attribute notation": {
+    "prefix": "fVariableValueAsAttributeNotation",
+    "body": [
+      "<f:variable name=\"$1\" value=\"$2\" />"
+    ],
+    "description": "TYPO3 Fluid | <f:variable>"
+  },
+  "f:variable Inline": {
+    "prefix": "fVariableInline",
+    "body": [
+      "{f:variable(name: '$1', value: '$2')}"
+    ],
+    "description": "TYPO3 Fluid inline | {f:variable()}"
   }
 }


### PR DESCRIPTION
New ViewHelper:

- base (no inline)
- cache.disabled
- cache.static (no inline version)
- cache.warmup (no inline version)
- inline (https://docs.typo3.org/typo3cms/ViewHelperReference/typo3fluid/fluid/latest/Inline.html)
- layout (no inline version)
- section (no inline version)
- spaceless (no inline version)
- variable

Updated ViewHelper:
- add 'defaultCase' to `switch` (no inline version)

Note: I am not sure, if inline notations for those ViewHelpers marked with "(no inline version)" are necessary. If so, I would prepare another PR.