### PR TITLE
Remove self-closing tag

### DIFF
--- a/snippets/fluid.json
+++ b/snippets/fluid.json
@@ -523,7 +523,7 @@
   "f:section": {
     "prefix": "fSection",
     "body": [
-      "<f:section name=\"$1\"/>$2</f:section>"
+      "<f:section name=\"$1\">$2</f:section>"
     ],
     "description": "TYPO3 Fluid | <f:section>"
   },


### PR DESCRIPTION
`fsection` had a self-closing and a closing tag, which caused troubles in fluid templates. Removing the self-closing tag solves the problem.